### PR TITLE
로그인 페이지의 url을 account/login/ 에서 accounts/login/으로 변경

### DIFF
--- a/account/urls.py
+++ b/account/urls.py
@@ -6,10 +6,10 @@ from .views import IdLogin, Logout
 
 urlpatterns = [
     path("auth/", include("dj_rest_auth.urls")),
-    path("account/login/", IdLogin.as_view(), name='account_login'),
-    path("account/email/", IdLogin.as_view(), name='account_email'),
-    path("account/logout/", Logout.as_view(), name='account_logout'),
-    path("account/signup/", IdLogin.as_view(), name="account_signup"),
+    path("accounts/login/", IdLogin.as_view(), name='account_login'),
+    path("accounts/email/", IdLogin.as_view(), name='account_email'),
+    path("accounts/logout/", Logout.as_view(), name='account_logout'),
+    path("accounts/signup/", IdLogin.as_view(), name="account_signup"),
     path("auth/github/login/", GitHubLogin.as_view(), name="github_login"),
     path("auth/google/login/", GoogleLogin.as_view(), name="google_login"),
     #path("my-page/payments", MyPage.as_view())

--- a/pyconkr/settings.py
+++ b/pyconkr/settings.py
@@ -235,4 +235,4 @@ OAUTH_GOOGLE_CALLBACK_URL = "http://localhost:8000/accounts/google/login/callbac
 
 # login_required view에 로그인 되지 않은 상태로 접속할 경우 리다이렉트할 로그인 페이지를 설정합니다.
 # The URL or named URL pattern where requests are redirected for login when using the login_required() decorator
-LOGIN_URL = '/account/login/'
+LOGIN_URL = '/accounts/login/'


### PR DESCRIPTION
### 목표
* 로그인 페이지의 url을 account/login/ 에서 accounts/login/으로 변경

### 작업 내용
* 로그인 페이지의 url을 account/login/ 에서 accounts/login/으로 변경

### 유의 사항
* 리뷰어는 `PyConKR-2023`을 지정해주세요.
* 작업한 내용을 상세하게 작성해주세요.