### PR TITLE
Fix: zappa_settings.json 가져오는 방식 변경

### DIFF
--- a/.github/workflows/deploy_on_dev.yml
+++ b/.github/workflows/deploy_on_dev.yml
@@ -57,18 +57,18 @@ jobs:
           pip install zappa
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
-      # Pull request dose not get the gitub action secrets
-      # this section will be applied to the deploy workflows
-      - name: Setup Auth for Private Repo
-        uses: webfactory/ssh-agent@v0.5.4
+      # Checkout and import zappa config
+      - name: Checkout secrets repo
+        uses: actions/checkout@v4
         with:
-          ssh-private-key: ${{ secrets.SSH_SECRET_GOLONY }}
-          #  ssh-private-key: ${{ secrets.GH_PYCONKR_SECRETS }}
-
-      - name: update pyconkr-secretes
-        run: |
-          chmod 775 ./update_secrets.sh
-          ./update_secrets.sh
+          repository: ${{ secrets.PYCONKR_SECRET_REPOSITORY }}
+          ssh-key: ${{ secrets.PYCONKR_SECRET_REPOSITORY_DEPLOY_KEY }}
+          path: secret_envs
+          clean: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            ${{ steps.info.outputs.repository_name }}/zappa_settings.json
+      - run: mv secret_envs/${{ steps.info.outputs.repository_name }}/zappa_settings.json ./zappa_settings.json && rm -rf secret_envs
 
       #      - name: Test with Django Test
       #        run: |

--- a/.github/workflows/deploy_on_prod.yml
+++ b/.github/workflows/deploy_on_prod.yml
@@ -57,18 +57,18 @@ jobs:
           pip install zappa
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
-      # Pull request dose not get the gitub action secrets
-      # this section will be applied to the deploy workflows
-      - name: Setup Auth for Private Repo
-        uses: webfactory/ssh-agent@v0.5.4
+      # Checkout and import zappa config
+      - name: Checkout secrets repo
+        uses: actions/checkout@v4
         with:
-          ssh-private-key: ${{ secrets.SSH_SECRET_GOLONY }}
-          #  ssh-private-key: ${{ secrets.GH_PYCONKR_SECRETS }}
-
-      - name: update pyconkr-secretes
-        run: |
-          chmod 775 ./update_secrets.sh
-          ./update_secrets.sh
+          repository: ${{ secrets.PYCONKR_SECRET_REPOSITORY }}
+          ssh-key: ${{ secrets.PYCONKR_SECRET_REPOSITORY_DEPLOY_KEY }}
+          path: secret_envs
+          clean: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            ${{ steps.info.outputs.repository_name }}/zappa_settings.json
+      - run: mv secret_envs/${{ steps.info.outputs.repository_name }}/zappa_settings.json ./zappa_settings.json && rm -rf secret_envs
 
       #      - name: Test with Django Test
       #        run: |


### PR DESCRIPTION
### 목표
* 현재 배포 중 zappa_settings.json을 가져오지 못해 배포가 안 되는 이슈를 수정합니다.

### 작업 내용
* 기존 update_secrets.sh 대신 Workflow에서 해당 repo를 pull 후 zappa_settings.json을 가져오도록 수정합니다.
