### PR TITLE
add cache for session list and retrieve API

### DIFF
--- a/pyconkr/settings.py
+++ b/pyconkr/settings.py
@@ -219,6 +219,16 @@ SPECTACULAR_SETTINGS = {
     "PREPROCESSING_HOOKS": ["pyconkr.openapi.preprocessing_filter_spec"],
 }
 
+
+# cache for django localmem
+# https://docs.djangoproject.com/en/5.1/topics/cache/#local-memory-caching
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "pyconkr-api-v2",
+    }
+}
+
 # CORS_ALLOW_ALL_ORIGINS = True
 CORS_ORIGIN_WHITELIST = (
     "https://2023.pycon.kr",

--- a/session/viewsets.py
+++ b/session/viewsets.py
@@ -1,4 +1,6 @@
 from django.conf import settings
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 from drf_spectacular.utils import OpenApiExample, OpenApiResponse, extend_schema
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
@@ -28,14 +30,24 @@ class SessionViewSet(ModelViewSet):
             200: OpenApiResponse(
                 response=str,
                 examples=[
-                    OpenApiExample(name="2023년 세션 목록", value=SessionListSerializer(many=True)),
-                    OpenApiExample(name="2024년 이후 세션 목록 (Pretalx)", value=PretalxSessionSerializer(many=True)),
+                    OpenApiExample(
+                        name="2023년 세션 목록", value=SessionListSerializer(many=True)
+                    ),
+                    OpenApiExample(
+                        name="2024년 이후 세션 목록 (Pretalx)",
+                        value=PretalxSessionSerializer(many=True),
+                    ),
                 ],
             ),
         },
     )
+    # cache list about 30 minutes
+    @method_decorator(cache_page(60 * 30))
     def list(self, request, *args, **kwargs) -> Response:
-        if request.version == 2023 or request.version not in settings.PRETALX.EVENT_NAME:
+        if (
+            request.version == 2023
+            or request.version not in settings.PRETALX.EVENT_NAME
+        ):
             return super().list(request, *args, **kwargs)
 
         pretalx_event_name = settings.PRETALX.EVENT_NAME[request.version]
@@ -52,13 +64,21 @@ class SessionViewSet(ModelViewSet):
                 response=str,
                 examples=[
                     OpenApiExample(name="2023년 세션 상세", value=SessionSerializer()),
-                    OpenApiExample(name="2024년 이후 세션 상세 (Pretalx)", value=PretalxSessionSerializer()),
+                    OpenApiExample(
+                        name="2024년 이후 세션 상세 (Pretalx)",
+                        value=PretalxSessionSerializer(),
+                    ),
                 ],
             ),
         },
     )
+    # cache each about 30 minutes
+    @method_decorator(cache_page(60 * 30))
     def retrieve(self, request, *args, **kwargs) -> Response:
-        if request.version == 2023 or request.version not in settings.PRETALX.EVENT_NAME:
+        if (
+            request.version == 2023
+            or request.version not in settings.PRETALX.EVENT_NAME
+        ):
             return super().retrieve(request, *args, **kwargs)
 
         pretalx_event_name = settings.PRETALX.EVENT_NAME[request.version]


### PR DESCRIPTION
### 목표
* https://api.pycon.kr/2024/sessions/ 의 반응속도를 줄인다.
* 해당 api 는 2024의 경우 `pretalx` 의 client 를 이용해서 가져오므로 1초 이상 걸림

### 작업 내용
* `settings.py` 에 localcache 설정
* `SessionViewSet` 의 `list` 와 `retrieve` 에 cache 30분 적용
* 람다 환경에서 [Local-memory caching](https://docs.djangoproject.com/en/5.1/topics/cache/#local-memory-caching) 이 동작하는지 테스트가 필요함. 동작하지 않을 경우에 /tmp 에 [file-system](https://docs.djangoproject.com/en/5.1/topics/cache/#filesystem-caching) 으로 캐슁을 하는 방향으로 전환
