### PR TITLE
어드민 페이지에서 후원사 정보가 보기 편하도록 수정

### DIFF
--- a/sponsor/admin.py
+++ b/sponsor/admin.py
@@ -20,8 +20,9 @@ class SponsorAdmin(SummernoteModelAdmin):
         "submitted",
         "accepted",
         "paid_at",
+        "year",
     )
-    list_filter = ("accepted", "submitted")
+    list_filter = ("accepted", "submitted", "paid_at")
     ordering = ("-created_at",)
 
 

--- a/sponsor/models.py
+++ b/sponsor/models.py
@@ -67,7 +67,7 @@ class SponsorLevel(models.Model):
         return Sponsor.objects.filter(level=self, submitted=True, accepted=True).count()
 
     def __str__(self):
-        return self.name
+        return f"({self.year}) {self.name}"
 
 
 class BenefitByLevel(models.Model):

--- a/sponsor/serializers.py
+++ b/sponsor/serializers.py
@@ -82,10 +82,6 @@ class SponsorSerializer(serializers.ModelSerializer):
 
 
 class SponsorLevelSerializer(serializers.ModelSerializer):
-    benefits = SponsorBenefitWithOfferSerializer(
-        many=True, read_only=True, source="benefit_by_level"
-    )
-
     class Meta:
         model = SponsorLevel
         fields = [
@@ -96,9 +92,17 @@ class SponsorLevelSerializer(serializers.ModelSerializer):
             "price",
             "limit",
             "order",
-            "benefits",
         ]
         read_only_fields = ["id"]
+
+
+class SponsorLevelWithBenefitSerializer(SponsorLevelSerializer):
+    benefits = SponsorBenefitWithOfferSerializer(
+        many=True, read_only=True, source="benefit_by_level"
+    )
+
+    class Meta(SponsorLevelSerializer.Meta):
+        fields = SponsorLevelSerializer.Meta.fields + ["benefits"]
 
 
 class SponsorSummariesSerializer(serializers.ModelSerializer):

--- a/sponsor/viewsets.py
+++ b/sponsor/viewsets.py
@@ -16,11 +16,11 @@ from sponsor.serializers import (
     PatronListSerializer,
     SponsorBenefitSerializer,
     SponsorDetailSerializer,
-    SponsorLevelSerializer,
     SponsorListSerializer,
     SponsorRemainingAccountSerializer,
     SponsorSerializer,
     SponsorWithLevelSerializer,
+    SponsorLevelWithBenefitSerializer,
 )
 from sponsor.slack import send_new_sponsor_notification
 from sponsor.validators import SponsorValidater
@@ -49,7 +49,7 @@ class SponsorLevelViewSet(ModelViewSet):
             case "list_with_levels":
                 return SponsorWithLevelSerializer
             case _:
-                return SponsorLevelSerializer
+                return SponsorLevelWithBenefitSerializer
 
     @action(detail=False, methods=["GET"], url_path="with-sponsor")
     def list_with_levels(self, request, version):


### PR DESCRIPTION
### 목표
* 어드민 페이지에서 후원사 정보가 보기 편하도록 수정

### 작업 내용
* 후원사 목록 조회 시 필요 없는 등급별 혜택 정보가 포함되지 않도록 수정
* 어드민 페이지에서 연도별로 후원사 등급 이름이 같은 경우 구분 할 수 있도록 연도 정보 추가
* 입금된 후원사만 볼 수 있도록 필터링 추가

### 유의 사항
* 리뷰어는 `PyConKR-2023`을 지정해주세요.
* 작업한 내용을 상세하게 작성해주세요.