### PR TITLE
fix api url with trailing slash

### DIFF
--- a/pyconkr/external_apis/pretalx/client.py
+++ b/pyconkr/external_apis/pretalx/client.py
@@ -43,7 +43,7 @@ class PretalxClient:
         """세션 목록 조회"""
         query_params = {"limit": 300, "state": "confirmed" if only_confirmed else None}
         filtered_query_params = {k: v for k, v in query_params.items() if v is not None}
-        endpoint = f"api/events/{event_name}/submissions?{urllib.parse.urlencode(filtered_query_params)}"
+        endpoint = f"api/events/{event_name}/submissions/?{urllib.parse.urlencode(filtered_query_params)}"
 
         try:
             result = self._request("GET", endpoint)
@@ -54,7 +54,7 @@ class PretalxClient:
 
     def retrieve_session(self, event_name: str, session_id: int) -> dict:
         """세션 상세 조회"""
-        endpoint = f"api/events/{event_name}/submissions/{session_id}"
+        endpoint = f"api/events/{event_name}/submissions/{session_id}/"
 
         try:
             result = self._request("GET", endpoint)


### PR DESCRIPTION
### 목표
* `petalx` API 호출시에 URL 이 301 이 되기에 tailing slash 를 추가
  * https://proposal.pycon.kr/api/events/pyconkr-2024/submissions
  * https://proposal.pycon.kr/api/events/pyconkr-2024/submissions/

### 작업 내용
* 

### 유의 사항
* 리뷰어는 `PyConKR-2023`을 지정해주세요.
* 작업한 내용을 상세하게 작성해주세요.